### PR TITLE
Update mutations.js

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/store/dag/mutations.js
+++ b/dolphinscheduler-ui/src/js/conf/home/store/dag/mutations.js
@@ -143,7 +143,7 @@ export default {
    */
   removeTask (state, code) {
     state.isEditDag = true
-    state.tasks = state.tasks.filter(task => task.code !== code)
+    state.tasks = state.tasks.filter(task => task.code === code)
   },
   resetLocalParam (state, payload) {
     const tasks = state.tasks


### PR DESCRIPTION
in origin version, when it's code not equals the previous code, the removeTask will take effect. 
after fixed, the removeTask function will take effect when delete the same code and the we can create another task instance with the same name.

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
